### PR TITLE
Added K = black

### DIFF
--- a/indicators.yml
+++ b/indicators.yml
@@ -1397,6 +1397,7 @@
    joe: American soldier
    jolly: Marine
    jug: prison
+   k: Black
    k: Kay
    k: Khmer Republic
    k: Kirkpatrick


### PR DESCRIPTION
K is sometimes used to represent the colour black, for example in the CMYK colour system. It's also often printed on black printer ink cartridges.